### PR TITLE
feat#1: migrate solidity contracts to cairo

### DIFF
--- a/contract_/.tool-versions
+++ b/contract_/.tool-versions
@@ -1,0 +1,2 @@
+starknet-foundry 0.37.0
+scarb 2.9.2

--- a/contract_/Scarb.lock
+++ b/contract_/Scarb.lock
@@ -5,8 +5,127 @@ version = 1
 name = "contract_"
 version = "0.1.0"
 dependencies = [
+ "openzeppelin",
  "snforge_std",
 ]
+
+[[package]]
+name = "openzeppelin"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:05fd9365be85a4a3e878135d5c52229f760b3861ce4ed314cb1e75b178b553da"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_finance",
+ "openzeppelin_governance",
+ "openzeppelin_introspection",
+ "openzeppelin_merkle_tree",
+ "openzeppelin_presets",
+ "openzeppelin_security",
+ "openzeppelin_token",
+ "openzeppelin_upgrades",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_access"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:7734901a0ca7a7065e69416fea615dd1dc586c8dc9e76c032f25ee62e8b2a06c"
+dependencies = [
+ "openzeppelin_introspection",
+]
+
+[[package]]
+name = "openzeppelin_account"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:1aa3a71e2f40f66f98d96aa9bf9f361f53db0fd20fa83ef7df04426a3c3a926a"
+dependencies = [
+ "openzeppelin_introspection",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_finance"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:f0c507fbff955e4180ea3fa17949c0ff85518c40101f4948948d9d9a74143d6c"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_token",
+]
+
+[[package]]
+name = "openzeppelin_governance"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:c0fb60fad716413d537fabd5fcbb2c499ca6beb95af5f0d1699955ecec4c6f63"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_introspection",
+ "openzeppelin_token",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_introspection"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:13e04a2190684e6804229a77a6c56de7d033db8b9ef519e5e8dee400a70d8a3d"
+
+[[package]]
+name = "openzeppelin_merkle_tree"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:039608900e92f3dcf479bf53a49a1fd76452acd97eb86e390d1eb92cacdaf3af"
+
+[[package]]
+name = "openzeppelin_presets"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:5c07a8de32e5d9abe33988c7927eaa8b5f83bc29dc77302d9c8c44c898611042"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_finance",
+ "openzeppelin_introspection",
+ "openzeppelin_token",
+ "openzeppelin_upgrades",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_security"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:27155597019ecf971c48d7bfb07fa58cdc146d5297745570071732abca17f19f"
+
+[[package]]
+name = "openzeppelin_token"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:4452f449dc6c1ea97cf69d1d9182749abd40e85bd826cd79652c06a627eafd91"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_introspection",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_upgrades"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:15fdd63f6b50a0fda7b3f8f434120aaf7637bcdfe6fd8d275ad57343d5ede5e1"
+
+[[package]]
+name = "openzeppelin_utils"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:44f32d242af1e43982decc49c563e613a9b67ade552f5c3d5cde504e92f74607"
 
 [[package]]
 name = "snforge_scarb_plugin"

--- a/contract_/Scarb.toml
+++ b/contract_/Scarb.toml
@@ -6,19 +6,12 @@ edition = "2024_07"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
+openzeppelin = "0.20.0"
 starknet = "2.9.2"
-openzeppelin_access = "1.0.0"
-openzeppelin_token = "1.0.0"
-
-# OpenZeppelin Contracts for Cairo
-openzeppelin_access = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.14.0" }
-openzeppelin_security = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.14.0" }
-openzeppelin_token = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.14.0" }
 
 [dev-dependencies]
 snforge_std = "0.37.0"
 assert_macros = "2.9.2"
-openzeppelin_utils = "1.0.0"
 
 [[target.starknet-contract]]
 sierra = true

--- a/contract_/src/lib.cairo
+++ b/contract_/src/lib.cairo
@@ -1,5 +1,1 @@
 pub mod BigIncGenesis;
-
-#[cfg(test)]
-pub mod tests {}
-


### PR DESCRIPTION
related issue  #1 

Made sure that the code compiles, cleaned up deps and kept similar logic to the original Solidity contracts.
I think having the `.tool-versions` is nice for contributors experience so that they know which version to use of the toolchain.

Note: the `donate` function is not yet implemented as Starknet doesn't have native ETH transfers like in Solidity, could be a nice first issue to have to implement the donate function to support usdt and usdc since they both have 6 decimals.

If there is anything that isn't clear I'm open to suggestions, looking forward to your review.